### PR TITLE
Fix for the gpflowflowSlim path

### DIFF
--- a/core/gpflowSlim/params.py
+++ b/core/gpflowSlim/params.py
@@ -22,14 +22,14 @@ import enum
 import numpy as np
 import tensorflow as tf
 
-from gpflowSlim import settings
+from core.gpflowSlim import settings
 
 
-from gpflowSlim.base import IPrior, ITransform
+from core.gpflowSlim.base import IPrior, ITransform
 
-from gpflowSlim import misc
+from core.gpflowSlim import misc
 
-from gpflowSlim.transforms import Identity
+from core.gpflowSlim.transforms import Identity
 
 
 class Parameter(object):


### PR DESCRIPTION
snapshot of error which was fixed using the changes in this PR.

Traceback (most recent call last):
  File "main.py", line 8, in <module>
    from tasks import regression
  File "/scratch/ssd001/home/farzaneh/fork/predictive-correlation-benchmark/tasks/regression.py", line 4, in <module>
    import core.gpflowSlim as gfs
  File "/scratch/ssd001/home/farzaneh/fork/predictive-correlation-benchmark/core/gpflowSlim/__init__.py", line 25, in <module>
    from . import conditionals
  File "/scratch/ssd001/home/farzaneh/fork/predictive-correlation-benchmark/core/gpflowSlim/conditionals.py", line 21, in <module>
    from .features import InducingPoints
  File "/scratch/ssd001/home/farzaneh/fork/predictive-correlation-benchmark/core/gpflowSlim/features.py", line 22, in <module>
    from . import conditionals, transforms, kernels, decors, settings
  File "/scratch/ssd001/home/farzaneh/fork/predictive-correlation-benchmark/core/gpflowSlim/kernels.py", line 29, in <module>
    from .params import Parameter
  File "/scratch/ssd001/home/farzaneh/fork/predictive-correlation-benchmark/core/gpflowSlim/params.py", line 25, in <module>
    from gpflowSlim import settings
ModuleNotFoundError: No module named 'gpflowSlim'